### PR TITLE
Add textAlign argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ To show a dialog, use the show method, to hide it, use the hide method. Simple l
 | horizontal  | Boolean value to set if loading has to show on horizontal | False   | false |
 | separation  | Double value to set the separation between loading and text | False   | 10.0 |
 | textStyle  | Style to customize the text inside dialog | False   | TextStyle(fontSize: 14) |
+| textAlign  | Alignment of the message | False   | TextAlign.center |
 | hideText  | Boolean value to hide the text widget | False   | false |
 | loadingIndicator  | Widget to use when type is set on custom.  | False (Required when type is custom)  |  |
 

--- a/lib/simple_fontico_loading.dart
+++ b/lib/simple_fontico_loading.dart
@@ -197,6 +197,7 @@ class SimpleFontelicoProgressDialog {
       bool horizontal = false,
       double separation = 10.0,
       TextStyle textStyle = const TextStyle(fontSize: 14),
+      TextAlign textAlign = TextAlign.center,
       bool hideText = false,
       Widget? loadingIndicator}) {
     assert(context != null, 'Context must not be null');
@@ -235,14 +236,14 @@ class SimpleFontelicoProgressDialog {
                             crossAxisAlignment: CrossAxisAlignment.center,
                             mainAxisSize: MainAxisSize.min,
                             children: _getChildren(type, _message, horizontal,
-                                separation, textStyle, hideText),
+                                separation, textStyle, textAlign, hideText),
                           )
                         : Row(
                             mainAxisAlignment: MainAxisAlignment.center,
                             crossAxisAlignment: CrossAxisAlignment.center,
                             mainAxisSize: MainAxisSize.min,
                             children: _getChildren(type, _message, horizontal,
-                                separation, textStyle, hideText),
+                                separation, textStyle, textAlign, hideText),
                           ),
                   ),
                 );
@@ -276,6 +277,7 @@ class SimpleFontelicoProgressDialog {
       bool horizontal,
       double separation,
       TextStyle textStyle,
+      TextAlign textAlign,
       bool hideText) {
     if (hideText) {
       return [_getLoadingIndicator(type)];
@@ -292,6 +294,7 @@ class SimpleFontelicoProgressDialog {
       Text(
         message!,
         style: textStyle,
+        textAlign: textAlign,
       )
     ];
   }


### PR DESCRIPTION
- Add textAlign argument to the _dialog.show() function.
- Update the Readme